### PR TITLE
fix: add SDK hook to correct improper string encoding for object|string values

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 9c76d982-a275-4b45-a46b-dccb6e2cffe9
 management:
-  docChecksum: e96990103b98a2e048512029c82fc4a4
+  docChecksum: 896e8b53e0968c892ab19f842b1234f7
   docVersion: 1.0.0
-  speakeasyVersion: 1.546.1
-  generationVersion: 2.604.2
-  releaseVersion: 1.9.0
-  configChecksum: e355f20311e52c699ff3a7f6128438a9
+  speakeasyVersion: 1.552.0
+  generationVersion: 2.610.0
+  releaseVersion: 1.10.0
+  configChecksum: f1a42a2f023c95e98d287f958c0b3b77
   repoURL: https://github.com/ragieai/ragie-typescript.git
   installationURL: https://github.com/ragieai/ragie-typescript
   published: true
@@ -14,7 +14,7 @@ features:
   typescript:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.1.11
-    core: 3.21.8
+    core: 3.21.9
     defaultEnabledRetries: 0.1.0
     devContainers: 2.90.0
     downloadStreams: 0.1.1
@@ -34,6 +34,7 @@ features:
     sdkHooks: 0.2.0
     unions: 2.85.8
     uploadStreams: 0.1.0
+    webhooks: 1.5.0
 generatedFiles:
   - .devcontainer/README.md
   - .devcontainer/devcontainer.json
@@ -48,10 +49,18 @@ generatedFiles:
   - docs/models/components/connection.md
   - docs/models/components/connectionbase.md
   - docs/models/components/connectionbasemetadata.md
+  - docs/models/components/connectionlimitexceededwebhook.md
+  - docs/models/components/connectionlimitexceededwebhookpayload.md
   - docs/models/components/connectionlimitparams.md
   - docs/models/components/connectionlist.md
   - docs/models/components/connectionmetadata.md
   - docs/models/components/connectionstats.md
+  - docs/models/components/connectionsyncfinishedwebhook.md
+  - docs/models/components/connectionsyncfinishedwebhookpayload.md
+  - docs/models/components/connectionsyncprogresswebhook.md
+  - docs/models/components/connectionsyncprogresswebhookpayload.md
+  - docs/models/components/connectionsyncstartedwebhook.md
+  - docs/models/components/connectionsyncstartedwebhookpayload.md
   - docs/models/components/connectorsource.md
   - docs/models/components/connectorsourcetypeinfo.md
   - docs/models/components/createdocumentfromurlparams.md
@@ -71,6 +80,8 @@ generatedFiles:
   - docs/models/components/documentchunkdetail.md
   - docs/models/components/documentchunklist.md
   - docs/models/components/documentdelete.md
+  - docs/models/components/documentdeletewebhook.md
+  - docs/models/components/documentdeletewebhookpayload.md
   - docs/models/components/documentfileupdate.md
   - docs/models/components/documentget.md
   - docs/models/components/documentgetmetadata.md
@@ -80,13 +91,18 @@ generatedFiles:
   - docs/models/components/documentmetadataupdatemetadata.md
   - docs/models/components/documentrawupdate.md
   - docs/models/components/documentsummary.md
+  - docs/models/components/documentupdatewebhook.md
+  - docs/models/components/documentupdatewebhookpayload.md
   - docs/models/components/documenturlupdate.md
   - docs/models/components/documentwithcontent.md
   - docs/models/components/documentwithcontentmetadata.md
   - docs/models/components/entity.md
+  - docs/models/components/entityextractedwebhook.md
+  - docs/models/components/entityextractedwebhookpayload.md
   - docs/models/components/entitylist.md
   - docs/models/components/filet.md
   - docs/models/components/instruction.md
+  - docs/models/components/limittype.md
   - docs/models/components/link.md
   - docs/models/components/listconnectorsourcetypeinfo.md
   - docs/models/components/loc.md
@@ -109,6 +125,8 @@ generatedFiles:
   - docs/models/components/pagination.md
   - docs/models/components/partition.md
   - docs/models/components/partitiondetail.md
+  - docs/models/components/partitionlimitexceededwebhook.md
+  - docs/models/components/partitionlimitexceededwebhookpayload.md
   - docs/models/components/partitionlimitparams.md
   - docs/models/components/partitionlimits.md
   - docs/models/components/partitionlist.md
@@ -185,6 +203,7 @@ generatedFiles:
   - docs/models/operations/updatedocumentfromurlrequest.md
   - docs/models/operations/updatedocumentrawrequest.md
   - docs/models/operations/updateinstructionrequest.md
+  - docs/models/webhooks/eventeventpostbody.md
   - docs/sdks/connections/README.md
   - docs/sdks/documents/README.md
   - docs/sdks/entities/README.md
@@ -306,9 +325,17 @@ generatedFiles:
   - src/models/components/audiomodalitydata.ts
   - src/models/components/connection.ts
   - src/models/components/connectionbase.ts
+  - src/models/components/connectionlimitexceededwebhook.ts
+  - src/models/components/connectionlimitexceededwebhookpayload.ts
   - src/models/components/connectionlimitparams.ts
   - src/models/components/connectionlist.ts
   - src/models/components/connectionstats.ts
+  - src/models/components/connectionsyncfinishedwebhook.ts
+  - src/models/components/connectionsyncfinishedwebhookpayload.ts
+  - src/models/components/connectionsyncprogresswebhook.ts
+  - src/models/components/connectionsyncprogresswebhookpayload.ts
+  - src/models/components/connectionsyncstartedwebhook.ts
+  - src/models/components/connectionsyncstartedwebhookpayload.ts
   - src/models/components/connectorsource.ts
   - src/models/components/connectorsourcetypeinfo.ts
   - src/models/components/createdocumentfromurlparams.ts
@@ -322,15 +349,21 @@ generatedFiles:
   - src/models/components/documentchunkdetail.ts
   - src/models/components/documentchunklist.ts
   - src/models/components/documentdelete.ts
+  - src/models/components/documentdeletewebhook.ts
+  - src/models/components/documentdeletewebhookpayload.ts
   - src/models/components/documentfileupdate.ts
   - src/models/components/documentget.ts
   - src/models/components/documentlist.ts
   - src/models/components/documentmetadataupdate.ts
   - src/models/components/documentrawupdate.ts
   - src/models/components/documentsummary.ts
+  - src/models/components/documentupdatewebhook.ts
+  - src/models/components/documentupdatewebhookpayload.ts
   - src/models/components/documenturlupdate.ts
   - src/models/components/documentwithcontent.ts
   - src/models/components/entity.ts
+  - src/models/components/entityextractedwebhook.ts
+  - src/models/components/entityextractedwebhookpayload.ts
   - src/models/components/entitylist.ts
   - src/models/components/index.ts
   - src/models/components/instruction.ts
@@ -342,6 +375,8 @@ generatedFiles:
   - src/models/components/pagination.ts
   - src/models/components/partition.ts
   - src/models/components/partitiondetail.ts
+  - src/models/components/partitionlimitexceededwebhook.ts
+  - src/models/components/partitionlimitexceededwebhookpayload.ts
   - src/models/components/partitionlimitparams.ts
   - src/models/components/partitionlimits.ts
   - src/models/components/partitionlist.ts
@@ -396,6 +431,8 @@ generatedFiles:
   - src/models/operations/updatedocumentfromurl.ts
   - src/models/operations/updatedocumentraw.ts
   - src/models/operations/updateinstruction.ts
+  - src/models/webhooks/eventeventpost.ts
+  - src/models/webhooks/index.ts
   - src/sdk/connections.ts
   - src/sdk/documents.ts
   - src/sdk/entities.ts
@@ -412,6 +449,7 @@ generatedFiles:
   - src/types/operations.ts
   - src/types/rfcdate.ts
   - src/types/streams.ts
+  - src/types/webhooks.ts
   - tsconfig.json
 examples:
   CreateDocument:
@@ -594,7 +632,7 @@ examples:
           document_id: "00000000-0000-0000-0000-000000000000"
           chunk_id: "00000000-0000-0000-0000-000000000000"
         query:
-          media_type: "video/mp4"
+          media_type: "text/plain"
           download: false
         header:
           partition: "acme_customer_id"
@@ -611,7 +649,7 @@ examples:
         path:
           document_id: "00000000-0000-0000-0000-000000000000"
         query:
-          media_type: "video/mp4"
+          media_type: "text/plain"
           download: false
         header:
           partition: "acme_customer_id"
@@ -921,5 +959,14 @@ examples:
           application/json: {}
         "401":
           application/json: {"detail": "<value>"}
+  eventevent_post:
+    speakeasy-default-eventevent-post:
+      requestBody:
+        application/json: {"nonce": "<value>", "type": "partition_limit_exceeded", "payload": {"partition": "<value>", "limit_type": "pages_hosted_limit_monthly"}}
+      responses:
+        "200":
+          application/json: "<value>"
+        "422":
+          application/json: {}
 examplesVersion: 1.0.2
 generatedTests: {}

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -19,7 +19,7 @@ generation:
     oAuth2ClientCredentialsEnabled: false
     oAuth2PasswordEnabled: false
 typescript:
-  version: 1.9.0
+  version: 1.10.0
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.546.1
+speakeasyVersion: 1.552.0
 sources:
     local:
         sourceNamespace: local
@@ -8,20 +8,19 @@ sources:
             - latest
     ragie.ai_spec:
         sourceNamespace: ragie-ai-spec
-        sourceRevisionDigest: sha256:10a0e07c612b57962ee039df1d8369436ef07e9241a35cc4bf85721f740240e0
-        sourceBlobDigest: sha256:fe68f5434abcfad6ee42c75a174de0c68a315c9085c972e996f3791ec0940d17
+        sourceRevisionDigest: sha256:80e9b1b59c79c147112229266ee88e72994d9139768a6b926a2dc117e7143576
+        sourceBlobDigest: sha256:5953b1b2da6594311578fd0bfd538d845f9a747a6a6e70d2db2d2bc42a1de42e
         tags:
             - latest
-            - speakeasy-sdk-regen-1745626915
             - 1.0.0
 targets:
     ragie:
         source: ragie.ai_spec
         sourceNamespace: ragie-ai-spec
-        sourceRevisionDigest: sha256:10a0e07c612b57962ee039df1d8369436ef07e9241a35cc4bf85721f740240e0
-        sourceBlobDigest: sha256:fe68f5434abcfad6ee42c75a174de0c68a315c9085c972e996f3791ec0940d17
+        sourceRevisionDigest: sha256:80e9b1b59c79c147112229266ee88e72994d9139768a6b926a2dc117e7143576
+        sourceBlobDigest: sha256:5953b1b2da6594311578fd0bfd538d845f9a747a6a6e70d2db2d2bc42a1de42e
         codeSamplesNamespace: ragie-ai-spec-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:7c9e0f4b7031eeaccb3f2da7bc3f48a5852b91dd86f45966e6b703dc4f2a681f
+        codeSamplesRevisionDigest: sha256:668bd1cf11bd5d009210d7bc9af71af9ff25c4070c6ff9b35a88fe4f545a85af
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/src/hooks/hooks.ts
+++ b/src/hooks/hooks.ts
@@ -18,6 +18,8 @@ import {
   SDKInitOptions,
 } from "./types.js";
 
+import { initHooks } from "./registration.js";
+
 export class SDKHooks implements Hooks {
   sdkInitHooks: SDKInitHook[] = [];
   beforeCreateRequestHooks: BeforeCreateRequestHook[] = [];
@@ -45,6 +47,7 @@ export class SDKHooks implements Hooks {
         this.registerAfterErrorHook(hook);
       }
     }
+    initHooks(this);
   }
 
   registerSDKInitHook(hook: SDKInitHook) {

--- a/src/hooks/registration.ts
+++ b/src/hooks/registration.ts
@@ -37,7 +37,6 @@ class DequoteBodyStringHook implements BeforeRequestHook {
 
     let modified = false;
     for (const field of this.fields) {
-      console.log("field", field);
       if (!formData.has(field)) continue;
       const originalValue = formData.get(field)?.toString();
 

--- a/src/hooks/registration.ts
+++ b/src/hooks/registration.ts
@@ -1,0 +1,61 @@
+import { BeforeRequestContext, BeforeRequestHook, Hooks } from "./types.js";
+
+/*
+ * This file is only ever generated once on the first generation and then is free to be modified.
+ * Any hooks you wish to add should be registered in the initHooks function. Feel free to define them
+ * in this file or in separate files in the hooks folder.
+ */
+
+export function initHooks(hooks: Hooks) {
+  // Add hooks by calling hooks.register{ClientInit/BeforeCreateRequest/BeforeRequest/AfterSuccess/AfterError}Hook
+  // with an instance of a hook that implements that specific Hook interface
+  // Hooks are registered per SDK instance, and are valid for the lifetime of the SDK instance
+
+  const createDocumentBodyFixerHook = new DequoteBodyStringHook(
+    "CreateDocument",
+    ["mode"],
+  );
+  hooks.registerBeforeRequestHook(createDocumentBodyFixerHook);
+}
+
+/**
+ * A hook that dequotes specific fields in the request body for a given
+ * operation ID.
+ */
+class DequoteBodyStringHook implements BeforeRequestHook {
+  constructor(
+    private readonly operationId: string,
+    private readonly fields: string[] = [],
+  ) {}
+
+  async beforeRequest(hookCtx: BeforeRequestContext, request: Request) {
+    if (hookCtx.operationID !== this.operationId) return request;
+
+    // Keep the original request/body safe
+    const clonedRequest = request.clone();
+    const formData = await clonedRequest.formData();
+
+    let modified = false;
+    for (const field of this.fields) {
+      console.log("field", field);
+      if (!formData.has(field)) continue;
+      const originalValue = formData.get(field)?.toString();
+
+      if (!originalValue) continue;
+
+      const isQuoteWrapped =
+        originalValue.startsWith('"') && originalValue.endsWith('"');
+
+      if (!isQuoteWrapped) continue;
+
+      formData.set(field, originalValue.slice(1, -1));
+      modified = true;
+    }
+
+    // If the body was modified, we need to remove the Content-Type header
+    // so the browser can set it correctly for FormData
+    if (modified) request.headers.delete("Content-Type");
+
+    return new Request(request, { body: formData });
+  }
+}

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -5,11 +5,13 @@
 import { HTTPClient, RequestInput } from "../lib/http.js";
 import { RetryConfig } from "../lib/retries.js";
 import { SecurityState } from "../lib/security.js";
+import { WebhookRecipient } from "../types/webhooks.js";
 
 export type HookContext = {
   baseURL: string | URL;
   operationID: string;
   oAuth2Scopes: string[] | null;
+  webhookRecipient?: WebhookRecipient;
   securitySource?: any | (() => Promise<any>);
   retryConfig: RetryConfig;
   resolvedSecurity: SecurityState | null;


### PR DESCRIPTION
Adds an SDK Hook to intercept certain API requests, and correct their improperly-encoded fields before sending them to the server.

After merging this, please regenerate the SDK _**before**_ publishing it to npm.